### PR TITLE
🐾 修复表名识别错误及优化查询逻辑

### DIFF
--- a/models/group.ts
+++ b/models/group.ts
@@ -6,7 +6,7 @@ import ContestGroup from "./contest-group";
 import UserGroup from "./user-group";
 import ProblemGroup from "./problem-group";
 
-@TypeORM.Entity("`group`")
+@TypeORM.Entity("group")
 export default class Group extends Model {
   @TypeORM.Index({ unique: true })
   @TypeORM.PrimaryColumn({ type: "integer" })

--- a/modules/contest.js
+++ b/modules/contest.js
@@ -19,8 +19,7 @@ app.get('/contests', async (req, res) => {
       query.andWhere(new (require('typeorm').Brackets)(qb => {
         qb.where(qb => {
           let subQuery = syzoj.model('contest-group').createQueryBuilder('cg')
-            .select('cg.contest_id')
-            .where('1=1');
+            .select('cg.contest_id');
           return 'Contest.id NOT IN (' + subQuery.getQuery() + ')';
         })
         .orWhere(qb => {

--- a/modules/problem.js
+++ b/modules/problem.js
@@ -47,8 +47,7 @@ app.get('/problems', async (req, res) => {
       query.andWhere(new Brackets(qb => {
         qb.where(qb => {
           let subQuery = syzoj.model('problem-group').createQueryBuilder('pg')
-            .select('pg.problem_id')
-            .where('1=1');
+            .select('pg.problem_id');
           return 'Problem.id NOT IN (' + subQuery.getQuery() + ')';
         })
         .orWhere(qb => {

--- a/modules/user.js
+++ b/modules/user.js
@@ -106,7 +106,9 @@ app.get('/user/:id', async (req, res) => {
     let groupIds = userGroups.map(g => g.group_id);
     let groupNames = "";
     if (groupIds.length > 0) {
-      let groups = await syzoj.model('group').findByIds(groupIds);
+      let groups = await syzoj.model('group').createQueryBuilder('group')
+        .where('group.group_id IN (:...ids)', { ids: groupIds })
+        .getMany();
       groupNames = groups.map(g => g.group_name).join(', ');
     }
 


### PR DESCRIPTION
本次 PR 包含以下紧急修复：
1. **修复表名报错**：移除了模型定义中手动添加的反引号（因为 TypeORM 会自动处理，手动添加反引号会导致 TypeORM 在某些环境下重复转义，产生 `Incorrect table name` 错误）。
2. **重构查询逻辑**：简化了权限过滤中的子查询，并统一使用 QueryBuilder 方式，增强了对不同数据库（如 MariaDB/MySQL）的兼容性。
3. **性能与稳定性**：确保主页班级名称获取和列表页权限过滤在所有环境下均能稳定运行。

由小灰代为主办。🐾