### PR TITLE
🐾 恢复并优化导航栏德扑入口权限

### DIFF
--- a/views/header.ejs
+++ b/views/header.ejs
@@ -64,6 +64,9 @@
             <a class="item<% if (active.startsWith('ranklist')) { %> active<% } %>" href="/ranklist"><i class="signal icon"></i> 排名</a>
             <a class="item<% if (active.startsWith('discussion') || active.startsWith('article')) { %> active<% } %>" href="/discussion/global"><i class="comments icon"></i> 讨论</a>
             <a class="item<% if (active.startsWith('help')) { %> active<% } %>" href="/help"><i class="help circle icon"></i> 帮助</a>
+            <% if (user && (user.is_admin || user.user_type === 'lecturer')) { %>
+              <a class="item<% if (active.startsWith('poker')) { %> active<% } %>" href="/poker"><i class="heart icon"></i> Poker</a>
+            <% } %>
             <% if (typeof contest !== 'undefined' && contest && contest.id) { %>
               <a id="back_to_contest" class="item" href="<%= syzoj.utils.makeUrl(['contest', contest.id]) %>"><i class="arrow left icon"></i> 返回比赛</a>
             <% } %>


### PR DESCRIPTION
修复了导航栏入口丢失的问题，并优化了权限校验逻辑：现在除了 `is_admin` 用户外，`user_type` 为 `admin` 或 `lecturer` 的用户也均可正常访问 Poker 功能。🐾