### PR TITLE
🐾 修复积分管理页面在德扑记录下的崩溃问题

### DIFF
--- a/views/admin_rating.ejs
+++ b/views/admin_rating.ejs
@@ -22,7 +22,7 @@
   <div class="ui relaxed divided list">
     <% for (const calc of calcs) { %>
       <div class="item">
-        <%= calc.contest.title %>
+        <%= calc.poker_name || (calc.contest && calc.contest.title) || "Unknown" %>
         <button name="calc_id" value="<%= calc.id %>" type="submit" style="color: #000; padding: 0; border: none; background: none;"><i class="remove icon"></i></button>
       </div>
     <% } %>


### PR DESCRIPTION
本次 PR 修复了一个关键的 UI 报错：当系统中存在非比赛关联的 Rating 变动（如德州扑克结算）时，后台 `admin_rating` 页面会因为尝试访问不存在的 `contest.title` 而崩溃。现在已增加兼容逻辑，优先显示德扑场次名或默认占位符。🐾