### PR TITLE
🐾 德州扑克 UI 优化：日志栏位置调整及高度增加

### DIFF
--- a/views/poker.ejs
+++ b/views/poker.ejs
@@ -69,6 +69,12 @@
                 <button onClick="call()" id="usernameCall" class="ui blue button menuButtons" style="display:none;">Call</button>
                 <button onClick="updateRaiseModal()" id="usernameRaise" class="ui orange button menuButtons" style="display:none;">Raise</button>
             </div>
+
+            <div class="ui segment">
+                <h4 class="ui dividing header">Game Log</h4>
+                <div id="gameLog" style="height: 250px; overflow-y: auto; font-family: monospace; font-size: 0.9em; padding: 5px; background: #f9f9f9; border: 1px solid #ddd;">
+                </div>
+            </div>
         </div>
         
         <div class="twelve wide column">
@@ -80,12 +86,6 @@
             <div class="ui segment">
                 <h4 class="ui dividing header">Opponents</h4>
                 <div id="opponentCards" class="ui cards"></div>
-            </div>
-
-            <div class="ui segment">
-                <h4 class="ui dividing header">Game Log</h4>
-                <div id="gameLog" style="height: 150px; overflow-y: auto; font-family: monospace; font-size: 0.9em; padding: 5px; background: #f9f9f9; border: 1px solid #ddd;">
-                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
本次 PR 针对德州扑克界面进行了细节优化：
1. **位置调整**：将 'Game Log' 日志栏从右侧对手区下方移至左侧操作按钮区下方，更符合玩家视线流动。
2. **容量增加**：将日志栏高度从 150px 提升至 250px，单次可见战况信息更丰富。🐾