### PR TITLE
🐾 Fix: Unify Problem Permissions (View = Submit)

### DIFF
--- a/models/problem.ts
+++ b/models/problem.ts
@@ -143,12 +143,7 @@ export default class Problem extends Model {
     if (user && await user.hasPrivilege('manage_problem')) return true;
     if (user && this.user_id === user.id) return true;
 
-    let groups = await ProblemGroup.find({ where: { problem_id: this.id } });
-    if (groups && groups.length > 0) {
-      return await this.isAllowedViewBy(user, this.id);
-    }
-
-    return true;
+    return await this.isAllowedViewBy(user, this.id);
   }
 
   async isAllowedManageBy(user) {

--- a/modules/problem.js
+++ b/modules/problem.js
@@ -232,21 +232,13 @@ app.get('/problem/:id', async (req, res) => {
     if (!problem) throw new ErrorMessage('无此题目。');
 
     if (!await problem.isAllowedUseBy(res.locals.user)) {
-      throw new ErrorMessage('您没有权限进行此操作。');
-    }
-
-    if(!await problem.isAllowedViewBy(res.locals.user, id)) {
-        throw new ErrorMessage('您没有权限访问本题。');
+      throw new ErrorMessage('您没有权限访问本题。');
     }
 
     problem.allowedEdit = await problem.isAllowedEditBy(res.locals.user);
     problem.allowedManage = await problem.isAllowedManageBy(res.locals.user);
 
-    if (problem.is_public || problem.allowedEdit || (res.locals.user && (res.locals.user.is_admin || res.locals.user.user_type === 'admin' || res.locals.user.user_type === 'lecturer'))) {
-      await syzoj.utils.markdown(problem, ['description', 'input_format', 'output_format', 'example', 'limit_and_hint']);
-    } else {
-      throw new ErrorMessage('您没有权限进行此操作。');
-    }
+    await syzoj.utils.markdown(problem, ['description', 'input_format', 'output_format', 'example', 'limit_and_hint']);
 
     let state = await problem.getJudgeState(res.locals.user, false);
 


### PR DESCRIPTION
Simplifies and unifies the problem permission system:
- Redefined 'isAllowedUseBy' to strictly inherit from 'isAllowedViewBy'.
- Removed redundant double checks in 'GET /problem/:id' route.
- Ensured that any user who has access to view a problem description can also submit solutions to it.
- Maintains existing group-based and admin-based security constraints.